### PR TITLE
Use React Portal in portal hoc

### DIFF
--- a/components/autocomplete/Autocomplete.js
+++ b/components/autocomplete/Autocomplete.js
@@ -8,381 +8,419 @@ import InjectChip from '../chip/Chip.js';
 import InjectInput from '../input/Input.js';
 import events from '../utils/events.js';
 
-const POSITION = {
-  AUTO: 'auto',
-  DOWN: 'down',
-  UP: 'up'
-};
-
 const factory = (Chip, Input) => {
   class Autocomplete extends Component {
-   static propTypes = {
-     allowCreate: PropTypes.bool,
-     className: PropTypes.string,
-     direction: PropTypes.oneOf(['auto', 'up', 'down']),
-     disabled: PropTypes.bool,
-     error: PropTypes.oneOfType([
-       PropTypes.string,
-       PropTypes.node
-     ]),
-     keepFocusOnChange: PropTypes.bool,
-     label: PropTypes.oneOfType([
-       PropTypes.string,
-       PropTypes.node
-     ]),
-     multiple: PropTypes.bool,
-     onBlur: PropTypes.func,
-     onChange: PropTypes.func,
-     onFocus: PropTypes.func,
-     onQueryChange: PropTypes.func,
-     selectedPosition: PropTypes.oneOf(['above', 'below', 'none']),
-     showSelectedWhenNotInSource: PropTypes.bool,
-     showSuggestionsWhenValueIsSet: PropTypes.bool,
-     source: PropTypes.any,
-     suggestionMatch: PropTypes.oneOf(['start', 'anywhere', 'word']),
-     theme: PropTypes.shape({
-       active: PropTypes.string,
-       autocomplete: PropTypes.string,
-       focus: PropTypes.string,
-       input: PropTypes.string,
-       suggestion: PropTypes.string,
-       suggestions: PropTypes.string,
-       up: PropTypes.string,
-       value: PropTypes.string,
-       values: PropTypes.string
-     }),
-     value: PropTypes.any
-   };
+    static propTypes = {
+      allowCreate: PropTypes.bool,
+      className: PropTypes.string,
+      direction: PropTypes.oneOf(['auto', 'up', 'down']),
+      disabled: PropTypes.bool,
+      error: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+      keepFocusOnChange: PropTypes.bool,
+      label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+      multiple: PropTypes.bool,
+      onBlur: PropTypes.func,
+      onChange: PropTypes.func,
+      onFocus: PropTypes.func,
+      onQueryChange: PropTypes.func,
+      selectedPosition: PropTypes.oneOf(['above', 'below', 'none']),
+      showSelectedWhenNotInSource: PropTypes.bool,
+      showSuggestionsWhenValueIsSet: PropTypes.bool,
+      source: PropTypes.any,
+      suggestionMatch: PropTypes.oneOf(['start', 'anywhere', 'word']),
+      theme: PropTypes.shape({
+        active: PropTypes.string,
+        autocomplete: PropTypes.string,
+        focus: PropTypes.string,
+        input: PropTypes.string,
+        suggestion: PropTypes.string,
+        suggestions: PropTypes.string,
+        up: PropTypes.string,
+        value: PropTypes.string,
+        values: PropTypes.string
+      }),
+      value: PropTypes.any
+    }
 
-   static defaultProps = {
-     allowCreate: false,
-     className: '',
-     direction: 'auto',
-     keepFocusOnChange: false,
-     multiple: true,
-     selectedPosition: 'above',
-     showSelectedWhenNotInSource: false,
-     showSuggestionsWhenValueIsSet: false,
-     source: {},
-     suggestionMatch: 'start'
-   };
+    static defaultProps = {
+      allowCreate: false,
+      className: '',
+      direction: 'auto',
+      keepFocusOnChange: false,
+      multiple: true,
+      selectedPosition: 'above',
+      showSelectedWhenNotInSource: false,
+      showSuggestionsWhenValueIsSet: false,
+      source: {},
+      suggestionMatch: 'start'
+    }
 
-   state = {
-     direction: this.props.direction,
-     focus: false,
-     showAllSuggestions: this.props.showSuggestionsWhenValueIsSet,
-     query: this.query(this.props.value),
-     isValueAnObject: false
-   };
+    state = {
+      direction: this.props.direction,
+      focus: false,
+      showAllSuggestions: this.props.showSuggestionsWhenValueIsSet,
+      query: this.query(this.props.value),
+      isValueAnObject: false
+    }
 
-   componentWillReceiveProps (nextProps) {
-     if (!this.props.multiple) {
-       this.setState({
-         query: this.query(nextProps.value)
-       });
-     }
-     if (this.state.focus && this.props.direction !== nextProps.direction) {
-       const direction = this.calculateDirection(nextProps.direction);
-       this.setState({ direction });
-     }
-   }
+    componentWillReceiveProps (nextProps) {
+      if (!this.props.multiple) {
+        this.setState({
+          query: this.query(nextProps.value)
+        });
+      }
+      if (this.state.focus && this.props.direction !== nextProps.direction) {
+        const direction = this.calculateDirection(nextProps.direction);
+        this.setState({ direction });
+      }
+    }
 
-   handleChange = (values, event) => {
-     const value = this.props.multiple ? values : values[0];
-     const { showSuggestionsWhenValueIsSet: showAllSuggestions } = this.props;
-     const query = this.query(value);
-     if (this.props.onChange) this.props.onChange(value, event);
-     if (this.props.keepFocusOnChange) {
-       this.setState({ query, showAllSuggestions });
-     } else {
-       this.setState({ focus: false, query, showAllSuggestions }, () => {
-         ReactDOM.findDOMNode(this).querySelector('input').blur();
-       });
-     }
-   };
+    handleChange = (values, event) => {
+      const value = this.props.multiple ? values : values[0];
+      const { showSuggestionsWhenValueIsSet: showAllSuggestions } = this.props;
+      const query = this.query(value);
+      if (this.props.onChange) this.props.onChange(value, event);
+      if (this.props.keepFocusOnChange) {
+        this.setState({ query, showAllSuggestions });
+      } else {
+        this.setState({ focus: false, query, showAllSuggestions }, () => {
+          ReactDOM.findDOMNode(this)
+            .querySelector('input')
+            .blur();
+        });
+      }
+    }
 
-   handleMouseDown = (event) => {
-     this.selectOrCreateActiveItem(event);
-   }
+    handleMouseDown = event => {
+      this.selectOrCreateActiveItem(event);
+    }
 
-   handleQueryBlur = (event) => {
-     if (this.state.focus) this.setState({focus: false});
-     if (this.props.onBlur) this.props.onBlur(event, this.state.active);
-   };
+    handleQueryBlur = event => {
+      if (this.state.focus) this.setState({ focus: false });
+      if (this.props.onBlur) this.props.onBlur(event, this.state.active);
+    }
 
-   handleQueryChange = (value) => {
-     if (this.props.onQueryChange) this.props.onQueryChange(value);
-     this.setState({query: value, showAllSuggestions: false, active: null});
-   };
+    handleQueryChange = value => {
+      if (this.props.onQueryChange) this.props.onQueryChange(value);
+      this.setState({ query: value, showAllSuggestions: false, active: null });
+    }
 
-   handleQueryFocus = (event) => {
-     this.suggestionsNode.scrollTop = 0;
-     this.setState({active: '', focus: true, direction: this.calculateDirection(this.props.direction)});
-     if (this.props.onFocus) this.props.onFocus(event);
-   };
+    handleQueryFocus = event => {
+      this.suggestionsNode.scrollTop = 0;
+      this.setState({
+        active: '',
+        focus: true,
+        direction: this.calculateDirection(this.props.direction)
+      });
+      if (this.props.onFocus) this.props.onFocus(event);
+    }
 
-   handleQueryKeyDown = (event) => {
-     // Clear query when pressing backspace and showing all suggestions.
-     const shouldClearQuery = (
-       event.which === 8
-       && this.props.showSuggestionsWhenValueIsSet
-       && this.state.showAllSuggestions
-     );
-     if (shouldClearQuery) {
-       this.setState({query: ''});
-     }
+    handleQueryKeyDown = event => {
+      // Clear query when pressing backspace and showing all suggestions.
+      const shouldClearQuery
+        = event.which === 8
+        && this.props.showSuggestionsWhenValueIsSet
+        && this.state.showAllSuggestions;
+      if (shouldClearQuery) {
+        this.setState({ query: '' });
+      }
 
-     if (event.which === 13) {
-       this.selectOrCreateActiveItem(event);
-     }
-   };
+      if (event.which === 13) {
+        this.selectOrCreateActiveItem(event);
+      }
+    }
 
-   handleQueryKeyUp = (event) => {
-     if (event.which === 27) ReactDOM.findDOMNode(this).querySelector('input').blur();
+    handleQueryKeyUp = event => {
+      if (event.which === 27) {
+ReactDOM.findDOMNode(this)
+          .querySelector('input')
+          .blur();
+}
 
-     if ([40, 38].indexOf(event.which) !== -1) {
-       const suggestionsKeys = [...this.suggestions().keys()];
-       let index = suggestionsKeys.indexOf(this.state.active) + (event.which === 40 ? +1 : -1);
-       if (index < 0) index = suggestionsKeys.length - 1;
-       if (index >= suggestionsKeys.length) index = 0;
-       this.setState({active: suggestionsKeys[index]});
-     }
-   };
+      if ([40, 38].indexOf(event.which) !== -1) {
+        const suggestionsKeys = [...this.suggestions().keys()];
+        let index
+          = suggestionsKeys.indexOf(this.state.active)
+          + (event.which === 40 ? +1 : -1);
+        if (index < 0) index = suggestionsKeys.length - 1;
+        if (index >= suggestionsKeys.length) index = 0;
+        this.setState({ active: suggestionsKeys[index] });
+      }
+    }
 
-   handleSuggestionHover = (event) => {
-     this.setState({active: event.target.id});
-   };
+    handleSuggestionHover = event => {
+      this.setState({ active: event.target.id });
+    }
 
-   calculateDirection (propsDirection) {
-     if (propsDirection === 'auto') {
-       const client = ReactDOM.findDOMNode(this.inputNode).getBoundingClientRect();
-       const screen_height = window.innerHeight || document.documentElement.offsetHeight;
-       const up = client.top > ((screen_height / 2) + client.height);
-       return up ? 'up' : 'down';
-     } else {
-       return propsDirection;
-     }
-   }
+    calculateDirection (propsDirection) {
+      if (propsDirection === 'auto') {
+        const client = ReactDOM.findDOMNode(
+          this.inputNode
+        ).getBoundingClientRect();
+        const screen_height
+          = window.innerHeight || document.documentElement.offsetHeight;
+        const up = client.top > screen_height / 2 + client.height;
+        return up ? 'up' : 'down';
+      } else {
+        return propsDirection;
+      }
+    }
 
-   query (key) {
+    query (key) {
       let query_value = '';
       if (!this.props.multiple && key) {
         const source_value = this.source().get(`${key}`);
         query_value = source_value ? source_value : key;
       }
       return query_value;
-   }
+    }
 
-   selectOrCreateActiveItem (event) {
-     let target = this.state.active;
-     if (!target) {
-       target = this.props.allowCreate
-         ? this.state.query
-         : [...this.suggestions().keys()][0];
-       this.setState({active: target});
-     }
-     this.select(event, target);
-   }
+    selectOrCreateActiveItem (event) {
+      let target = this.state.active;
+      if (!target) {
+        target = this.props.allowCreate
+          ? this.state.query
+          : [...this.suggestions().keys()][0];
+        this.setState({ active: target });
+      }
+      this.select(event, target);
+    }
 
-   suggestions () {
-     let suggest = new Map();
-     const rawQuery = this.state.query || (this.props.multiple ? '' : this.props.value);
-     const query = (`${rawQuery}`).toLowerCase().trim();
-     const values = this.values();
-     const source = this.source();
+    suggestions () {
+      let suggest = new Map();
+      const rawQuery
+        = this.state.query || (this.props.multiple ? '' : this.props.value);
+      const query = `${rawQuery}`.toLowerCase().trim();
+      const values = this.values();
+      const source = this.source();
 
-     // Suggest any non-set value which matches the query
-     if (this.props.multiple) {
-       for (const [key, value] of source) {
-         if (!values.has(key) && this.matches(value.toLowerCase().trim(), query)) {
-           suggest.set(key, value);
-         }
-       }
+      // Suggest any non-set value which matches the query
+      if (this.props.multiple) {
+        for (const [key, value] of source) {
+          if (
+            !values.has(key)
+            && this.matches(value.toLowerCase().trim(), query)
+          ) {
+            suggest.set(key, value);
+          }
+        }
 
-     // When multiple is false, suggest any value which matches the query if showAllSuggestions is false
-     } else if (query && !this.state.showAllSuggestions) {
-       for (const [key, value] of source) {
-         if (this.matches(value.toLowerCase().trim(), query)) {
-           suggest.set(key, value);
-         }
-       }
+        // When multiple is false, suggest any value which matches the query if showAllSuggestions is false
+      } else if (query && !this.state.showAllSuggestions) {
+        for (const [key, value] of source) {
+          if (this.matches(value.toLowerCase().trim(), query)) {
+            suggest.set(key, value);
+          }
+        }
 
-     // When multiple is false, suggest all values when showAllSuggestions is true
-     } else {
-       suggest = source;
-     }
+        // When multiple is false, suggest all values when showAllSuggestions is true
+      } else {
+        suggest = source;
+      }
 
-     return suggest;
-   }
+      return suggest;
+    }
 
-   matches (value, query) {
-     const { suggestionMatch } = this.props;
+    matches (value, query) {
+      const { suggestionMatch } = this.props;
 
-     if (suggestionMatch === 'start') {
-       return value.startsWith(query);
-     } else if (suggestionMatch === 'anywhere') {
-       return value.includes(query);
-     } else if (suggestionMatch === 'word') {
-       const re = new RegExp(`\\b${query}`, 'g');
-       return re.test(value);
-     }
+      if (suggestionMatch === 'start') {
+        return value.startsWith(query);
+      } else if (suggestionMatch === 'anywhere') {
+        return value.includes(query);
+      } else if (suggestionMatch === 'word') {
+        const re = new RegExp(`\\b${query}`, 'g');
+        return re.test(value);
+      }
 
-     return false;
-   }
+      return false;
+    }
 
-   source () {
-     const { source: src } = this.props;
-     if (src.hasOwnProperty('length')) {
-       return new Map(src.map((item) => Array.isArray(item) ? [...item] : [item, item]));
-     } else {
-       return new Map(Object.keys(src).map((key) => [`${key}`, src[key]]));
-     }
-   }
+    source () {
+      const { source: src } = this.props;
+      if (src.hasOwnProperty('length')) {
+        return new Map(
+          src.map(item => (Array.isArray(item) ? [...item] : [item, item]))
+        );
+      } else {
+        return new Map(Object.keys(src).map(key => [`${key}`, src[key]]));
+      }
+    }
 
-   values () {
-     let vals = this.props.multiple ? this.props.value : [this.props.value];
+    values () {
+      let vals = this.props.multiple ? this.props.value : [this.props.value];
 
-     if (!vals) vals = [];
+      if (!vals) vals = [];
 
-     if (this.props.showSelectedWhenNotInSource && this.isValueAnObject()) {
-       return new Map(Object.entries(vals));
-     }
+      if (this.props.showSelectedWhenNotInSource && this.isValueAnObject()) {
+        return new Map(Object.entries(vals));
+      }
 
-     const valueMap = new Map();
+      const valueMap = new Map();
 
-     const stringVals = vals.map(v => `${v}`);
-     for (const [k, v] of this.source()) {
-       if (stringVals.indexOf(k) !== -1) valueMap.set(k, v);
-     }
+      const stringVals = vals.map(v => `${v}`);
+      for (const [k, v] of this.source()) {
+        if (stringVals.indexOf(k) !== -1) valueMap.set(k, v);
+      }
 
-     return valueMap;
-   }
+      return valueMap;
+    }
 
-   select = (event, target) => {
-     events.pauseEvent(event);
-     const values = this.values(this.props.value);
-     const source = this.source();
-     const newValue = target === void 0 ? event.target.id : target;
+    select = (event, target) => {
+      events.pauseEvent(event);
+      const values = this.values(this.props.value);
+      const source = this.source();
+      const newValue = target === void 0 ? event.target.id : target;
 
-     if (this.isValueAnObject()) {
-       const newItem = Array.from(source).reduce((obj, [k, value]) => {
-         if (k === newValue) {
-           obj[k] = value;
-         }
-         return obj;
-       }, {});
+      if (this.isValueAnObject()) {
+        const newItem = Array.from(source).reduce((obj, [k, value]) => {
+          if (k === newValue) {
+            obj[k] = value;
+          }
+          return obj;
+        }, {});
 
-       return this.handleChange(Object.assign(this.mapToObject(values), newItem), event);
-     }
+        return this.handleChange(
+          Object.assign(this.mapToObject(values), newItem),
+          event
+        );
+      }
 
-     this.handleChange([newValue, ...values.keys()], event);
-   };
+      this.handleChange([newValue, ...values.keys()], event);
+    }
 
-   unselect (key, event) {
-     if (!this.props.disabled) {
-       const values = this.values(this.props.value);
+    unselect (key, event) {
+      if (!this.props.disabled) {
+        const values = this.values(this.props.value);
 
-       values.delete(key);
+        values.delete(key);
 
-       if (this.isValueAnObject()) {
-         return this.handleChange(this.mapToObject(values), event);
-       }
+        if (this.isValueAnObject()) {
+          return this.handleChange(this.mapToObject(values), event);
+        }
 
-       this.handleChange([...values.keys()], event);
-     }
-   }
+        this.handleChange([...values.keys()], event);
+      }
+    }
 
-   isValueAnObject () {
-      return !Array.isArray(this.props.value) && typeof this.props.value === 'object';
-   }
+    isValueAnObject () {
+      return (
+        !Array.isArray(this.props.value) && typeof this.props.value === 'object'
+      );
+    }
 
-   mapToObject (map) {
+    mapToObject (map) {
       return Array.from(map).reduce((obj, [k, value]) => {
         obj[k] = value;
         return obj;
       }, {});
-   }
+    }
 
-   renderSelected () {
-     if (this.props.multiple) {
-       const selectedItems = [...this.values()].map(([key, value]) => {
-         return (
-           <Chip
-             key={key}
-             className={this.props.theme.value}
-             deletable
-             onDeleteClick={this.unselect.bind(this, key)}
-           >
-             {value}
-           </Chip>
-         );
-       });
+    renderSelected () {
+      if (this.props.multiple) {
+        const selectedItems = [...this.values()].map(([key, value]) => {
+          return (
+            <Chip
+              key={key}
+              className={this.props.theme.value}
+              deletable
+              onDeleteClick={this.unselect.bind(this, key)}
+            >
+              {value}
+            </Chip>
+          );
+        });
 
-       return <ul className={this.props.theme.values}>{selectedItems}</ul>;
-     }
-   }
+        return <ul className={this.props.theme.values}>{selectedItems}</ul>;
+      }
+    }
 
-   renderSuggestions () {
-     const { theme } = this.props;
-     const suggestions = [...this.suggestions()].map(([key, value]) => {
-       const className = classnames(theme.suggestion, {[theme.active]: this.state.active === key});
-       return (
-         <li
-           id={key}
-           key={key}
-           className={className}
-           onMouseDown={this.handleMouseDown}
-           onMouseOver={this.handleSuggestionHover}
-         >
-           {value}
-         </li>
-       );
-     });
+    renderSuggestions () {
+      const { theme } = this.props;
+      const suggestions = [...this.suggestions()].map(([key, value]) => {
+        const className = classnames(theme.suggestion, {
+          [theme.active]: this.state.active === key
+        });
+        return (
+          <li
+            id={key}
+            key={key}
+            className={className}
+            onMouseDown={this.handleMouseDown}
+            onMouseOver={this.handleSuggestionHover}
+          >
+            {value}
+          </li>
+        );
+      });
 
-     return (
-       <ul
-         className={classnames(theme.suggestions, {[theme.up]: this.state.direction === 'up'})}
-         ref={node => { this.suggestionsNode = node; }}
-       >
-         {suggestions}
-       </ul>
-     );
-   }
+      return (
+        <ul
+          className={classnames(theme.suggestions, {
+            [theme.up]: this.state.direction === 'up'
+          })}
+          ref={node => {
+            this.suggestionsNode = node;
+          }}
+        >
+          {suggestions}
+        </ul>
+      );
+    }
 
-   render () {
-     const {
-      allowCreate, error, label, source, suggestionMatch, //eslint-disable-line no-unused-vars
-      selectedPosition, keepFocusOnChange, showSuggestionsWhenValueIsSet, showSelectedWhenNotInSource, onQueryChange,   //eslint-disable-line no-unused-vars
-      theme, ...other
-    } = this.props;
-     const className = classnames(theme.autocomplete, {
-       [theme.focus]: this.state.focus
-     }, this.props.className);
+    render () {
+      const {
+        allowCreate,
+        error,
+        label,
+        source,
+        suggestionMatch, //eslint-disable-line no-unused-vars
+        selectedPosition,
+        keepFocusOnChange,
+        showSuggestionsWhenValueIsSet,
+        showSelectedWhenNotInSource,
+        onQueryChange, //eslint-disable-line no-unused-vars
+        theme,
+        ...other
+      } = this.props;
+      const className = classnames(
+        theme.autocomplete,
+        {
+          [theme.focus]: this.state.focus
+        },
+        this.props.className
+      );
 
-     return (
-       <div data-react-toolbox='autocomplete' className={className}>
-         {this.props.selectedPosition === 'above' ? this.renderSelected() : null}
-         <Input
-           {...other}
-           ref={node => { this.inputNode = node; }}
-           autoComplete="off"
-           className={theme.input}
-           error={error}
-           label={label}
-           onBlur={this.handleQueryBlur}
-           onChange={this.handleQueryChange}
-           onFocus={this.handleQueryFocus}
-           onKeyDown={this.handleQueryKeyDown}
-           onKeyUp={this.handleQueryKeyUp}
-           theme={theme}
-           themeNamespace="input"
-           value={this.state.query}
-         />
-         {this.renderSuggestions()}
-         {this.props.selectedPosition === 'below' ? this.renderSelected() : null}
-       </div>
-     );
-   }
+      return (
+        <div data-react-toolbox="autocomplete" className={className}>
+          {this.props.selectedPosition === 'above'
+            ? this.renderSelected()
+            : null}
+          <Input
+            {...other}
+            ref={node => {
+              this.inputNode = node;
+            }}
+            autoComplete="off"
+            className={theme.input}
+            error={error}
+            label={label}
+            onBlur={this.handleQueryBlur}
+            onChange={this.handleQueryChange}
+            onFocus={this.handleQueryFocus}
+            onKeyDown={this.handleQueryKeyDown}
+            onKeyUp={this.handleQueryKeyUp}
+            theme={theme}
+            themeNamespace="input"
+            value={this.state.query}
+          />
+          {this.renderSuggestions()}
+          {this.props.selectedPosition === 'below'
+            ? this.renderSelected()
+            : null}
+        </div>
+      );
+    }
   }
 
   return Autocomplete;

--- a/components/hoc/Portal.js
+++ b/components/hoc/Portal.js
@@ -1,102 +1,34 @@
-import PropTypes from 'prop-types';
 import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
 
 class Portal extends Component {
   static propTypes = {
-    children: PropTypes.any,
-    container: PropTypes.any,
-    lockBody: PropTypes.bool
+    children: PropTypes.node,
+    className: PropTypes.string,
+    container: PropTypes.node
   }
 
-  static defaultProps = {
-    lockBody: true
+  constructor (props) {
+    super(props);
+    this._portalContainerNode = document.createElement('div');
   }
 
   componentDidMount () {
-    this._renderOverlay();
-  }
-
-  componentWillReceiveProps (nextProps) {
-    if (this._overlayTarget && nextProps.container !== this.props.container) {
-      this._portalContainerNode.removeChild(this._overlayTarget);
-      this._portalContainerNode = getContainer(nextProps.container);
-      this._portalContainerNode.appendChild(this._overlayTarget);
-    }
-  }
-
-  componentDidUpdate () {
-    this._renderOverlay();
+    getContainer(this.props.container).appendChild(this._portalContainerNode);
   }
 
   componentWillUnmount () {
-    this._unrenderOverlay();
-    this._unmountOverlayTarget();
-  }
-
-  _mountOverlayTarget () {
-    if (!this._overlayTarget) {
-      this._overlayTarget = document.createElement('div');
-      this._portalContainerNode = getContainer(this.props.container);
-      this._portalContainerNode.appendChild(this._overlayTarget);
-    }
-  }
-
-  _unmountOverlayTarget () {
-    if (this._overlayTarget) {
-      this._portalContainerNode.removeChild(this._overlayTarget);
-      this._overlayTarget = null;
-    }
-    this._portalContainerNode = null;
-  }
-
-  _renderOverlay () {
-    const overlay = !this.props.children
-      ? null
-      : React.Children.only(this.props.children);
-
-    if (overlay !== null) {
-      this._mountOverlayTarget();
-      this._overlayInstance = ReactDOM.unstable_renderSubtreeIntoContainer(
-        this, overlay, this._overlayTarget
-      );
-    } else {
-      this._unrenderOverlay();
-      this._unmountOverlayTarget();
-    }
-  }
-
-  _unrenderOverlay () {
-    if (this._overlayTarget) {
-      ReactDOM.unmountComponentAtNode(this._overlayTarget);
-      this._overlayInstance = null;
-    }
-  }
-
-  getMountNode () {
-    return this._overlayTarget;
-  }
-
-  getOverlayDOMNode () {
-    if (!this.isMounted()) {
-      throw new Error('getOverlayDOMNode(): A component must be mounted to have a DOM node.');
-    }
-
-    if (this._overlayInstance) {
-      if (this._overlayInstance.getWrappedDOMNode) {
-        return this._overlayInstance.getWrappedDOMNode();
-      } else {
-        return ReactDOM.findDOMNode(this._overlayInstance);
-      }
-    }
-
-    return null;
+    getContainer(this.props.container).removeChild(this._portalContainerNode);
   }
 
   render () {
-    return null;
-  }
+    const portalRender = (
+      <div className={this.props.className}>{this.props.children}</div>
+    );
 
+    return ReactDOM.createPortal(portalRender, this._portalContainerNode);
+  }
 }
 
 function getContainer (container) {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "@bionikspoon/react-toolbox",
-  "description": "A set of React components implementing Google's Material Design specification with the power of CSS Modules.",
+  "description":
+    "A set of React components implementing Google's Material Design specification with the power of CSS Modules.",
   "homepage": "http://www.react-toolbox.io",
-  "version": "1.4.0",
+  "version": "2.0.0",
   "main": "./lib",
   "author": {
     "name": "React Toolbox Team",
@@ -77,7 +78,7 @@
     "karma-webpack": "^1.8.0",
     "lint-staged": "^3.2.3",
     "mocha": "^3.2.0",
-    "node-sass": "^3.13.0",
+    "node-sass": "^4.9.0",
     "phantomjs-prebuilt": "^2.1.14",
     "postcss-loader": "^1.2.1",
     "pre-commit": "^1.2.2",
@@ -99,26 +100,29 @@
   },
   "scripts": {
     "babel": "babel ./components --out-dir ./lib",
-    "build": "cross-env NODE_ENV=production npm run babel && npm run sass && npm run tsd",
+    "build":
+      "cross-env NODE_ENV=production npm run babel && npm run sass && npm run tsd",
     "clean": "rimraf ./lib",
     "lint": "npm run lint:js && npm run lint:scss",
     "lint:js": "eslint ./ --ext .js",
-    "lint:scss": "sass-lint ./components/**/*.scss -v -i ./components/slider/style.scss",
+    "lint:scss":
+      "sass-lint ./components/**/*.scss -v -i ./components/slider/style.scss",
     "lint:staged": "lint-staged",
     "patch": "bumped release patch",
     "prebuild": "npm run clean",
     "prepublish": "npm run build",
     "release": "bumped release",
     "sass": "cpx \"./components/**/*.scss\" ./lib",
-    "start": "cross-env NODE_ENV=development UV_THREADPOOL_SIZE=100 node ./server",
+    "start":
+      "cross-env NODE_ENV=development UV_THREADPOOL_SIZE=100 node ./server",
     "test": "cross-env NODE_ENV=test karma start",
     "test:watch": "cross-env NODE_ENV=test karma start --no-single-run",
     "tsd": "cpx \"./components/**/*.d.ts\" ./lib"
   },
   "license": "MIT",
   "peerDependencies": {
-    "react": "^0.14 || ~15.4.0 || ^16.0.0",
-    "react-dom": "^0.14.0 || ~15.4.0 || ^16.0.0"
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0"
   },
   "pre-commit": "lint:staged"
 }


### PR DESCRIPTION
Currently, this uses its own implementation of Portal in `components/hoc/portal`. 

When testing components with Enzyme, the contents of the portal are not rendered, making it difficult to test any pages or components that use the `Dialog` component. 

This PR migrates the portal hoc to use the new React 16 Portal API. 